### PR TITLE
Stable build & light image

### DIFF
--- a/hako/2.3.1/Dockerfile
+++ b/hako/2.3.1/Dockerfile
@@ -1,4 +1,20 @@
+FROM alpine:3.8 AS builder
+RUN apk add --update --no-cache --virtual .build-base build-base git \
+      && git clone https://github.com/google/jsonnet.git \
+      && cd jsonnet \
+      && make libjsonnet.so \
+      && mkdir -p /opt/jsonnet \
+      && cp libjsonnet.so /opt/jsonnet/libjsonnet.so \
+      && cp include/libjsonnet.h /opt/jsonnet/libjsonnet.h \
+      && cd .. \
+      && rm -rf jsonnet \
+      && apk del --purge .build-base
+
 FROM ruby:2.5-alpine3.8
-RUN apk --update --no-cache add openssh git zip make docker g++
-RUN gem install hako -v 2.3.1 -N --no-rdoc --no-ri
-RUN rm -rf /root/.cache
+RUN apk --update --no-cache add openssh git zip make docker
+COPY --from=builder /opt/jsonnet/libjsonnet.so /usr/local/lib/libjsonnet.so
+COPY --from=builder /opt/jsonnet/libjsonnet.h /usr/local/include/libjsonnet.h
+RUN apk add --update --no-cache --virtual .build-deps g++ \
+      && JSONNET_USE_SYSTEM_LIBRARIES=1 gem install hako -v 2.3.1 -N --no-rdoc --no-ri \
+      && apk del --purge .build-deps
+


### PR DESCRIPTION
Sometimes installing hako is failed, because building jsonnet by gem is unstable, so change jsonnet lib build way as follows: https://github.com/yugui/ruby-jsonnet .
Then, the builds will become stable and the image become light weight (479MB -> 272MB).
