### PR TITLE
Move terraform-tfnotify to https://github.com/gunosy/ci-terraform-tfnotify

### DIFF
--- a/terraform-tfnotify/0.11.11/Dockerfile
+++ b/terraform-tfnotify/0.11.11/Dockerfile
@@ -1,8 +1,0 @@
-FROM hashicorp/terraform:0.11.11
-
-ENV TFNOTIFY_VERSION=0.3.0
-
-RUN curl -sL https://github.com/mercari/tfnotify/releases/download/v${TFNOTIFY_VERSION}/tfnotify_v${TFNOTIFY_VERSION}_linux_amd64.tar.gz -o /tmp/tfnotify.tar.gz && \
-    tar zxvf /tmp/tfnotify.tar.gz -C /tmp && \
-    cp /tmp/tfnotify_v${TFNOTIFY_VERSION}_linux_amd64/tfnotify /usr/local/bin/tfnotify && \
-    rm -rf /tmp/*


### PR DESCRIPTION
Create a new repository https://github.com/gunosy/ci-terraform-tfnotify for `terraform-tfnotify` images, so remove terraform-tfnotify from this repository.